### PR TITLE
Add ignore_run_exports for python

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,6 +64,8 @@ outputs:
         # unfortunately, swig overlinks liblalburst into the python
         # bindings on linux
         - lalburst  # [not linux]
+        # nothing actually links against libpython
+        - python
     script: install-python.sh
     requirements:
       build:


### PR DESCRIPTION
This PR adds a `ignore_run_exports` declaration for python itself, to fix the latest build issue. The build number has not been bumped because the last `master` build failed.

Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
